### PR TITLE
reverse_proxy: Fix react websocket connection

### DIFF
--- a/reverse_proxy/nginx.conf
+++ b/reverse_proxy/nginx.conf
@@ -1,7 +1,8 @@
 # Server listening on	:80 and :443
-# Redirecting from		:80			->	https://
-# Reverse proxy from	/pgadmin	->	pgadmin/
-# Reverse proxy from	/api		->	backend/
+# Redirecting from		:80				->	https://
+# Reverse proxy from	/pgadmin		->	pgadmin/
+# Reverse proxy from	/api			->	backend/
+# Reverse proxy from	/sockjs-node	->	
 
 events {
 
@@ -46,6 +47,15 @@ http {
         	proxy_set_header	Host			$host;
 
 			proxy_pass			http://frontend:3000;
+		}
+
+		location /sockjs-node {
+			proxy_pass http://frontend:3000/sockjs-node;
+			proxy_http_version 1.1;
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_set_header Connection 'upgrade';
+			proxy_set_header Host $host;
+			proxy_cache_bypass $http_upgrade;
 		}
 	}
 


### PR DESCRIPTION
Fixes the error in console and should enable auto-refresh again.